### PR TITLE
Support .NET 6 in clients

### DIFF
--- a/src/fiskaltrust.Middleware.Interface.Client.Common/fiskaltrust.Middleware.Interface.Client.Common.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Common/fiskaltrust.Middleware.Interface.Client.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net6</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcClientOptions.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcClientOptions.cs
@@ -1,14 +1,23 @@
-﻿using Grpc.Core;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+#if NET6_0_OR_GREATER
+using Grpc.Net.Client;
+#else
+using Grpc.Core;
+#endif
 
 namespace fiskaltrust.Middleware.Interface.Client.Grpc
 {
     /// <summary>
-    /// Client Options ChannelCredentials and ChannelOptions.
+    /// Can be used to specify additional details of the gRPC connection
     /// </summary>
     public class GrpcClientOptions : ClientOptions
     {
+#if NET6_0_OR_GREATER
+        public GrpcChannelOptions ChannelOptions { get; set; } = new GrpcChannelOptions();
+        public bool AllowUnencryptedHttp2 { get; set; } = true;
+#else
         public ChannelCredentials ChannelCredentials { get; set; } = ChannelCredentials.Insecure;
         public List<ChannelOption> ChannelOptions { get; set; } = new List<ChannelOption>();
+#endif
     }
 }

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcDESSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcDESSCDFactory.cs
@@ -5,13 +5,17 @@ using System.Threading.Tasks;
 namespace fiskaltrust.Middleware.Interface.Client.Grpc
 {
     /// <summary>
-    /// Create grpc SSCD.
+    /// A factory to create a gRPC-based IDESSCD client instance for communicating with a German SCU package.
     /// </summary>
     public static class GrpcDESSCDFactory
     {
         public static async Task<IDESSCD> CreateSSCDAsync(GrpcClientOptions options)
         {
+#if NET6_0_OR_GREATER
             var connectionhandler = new GrpcProxyConnectionHandler<IDESSCD>(options);
+#else
+            var connectionhandler = new NativeGrpcProxyConnectionHandler<IDESSCD>(options);
+#endif
 
             if (options.RetryPolicyOptions != null)
             {

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcMESSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcMESSCDFactory.cs
@@ -5,13 +5,17 @@ using System.Threading.Tasks;
 namespace fiskaltrust.Middleware.Interface.Client.Grpc
 {
     /// <summary>
-    /// Create grpc SSCD.
+    /// A factory to create a gRPC-based IDESSCD client instance for communicating with a Montenegrin SCU package.
     /// </summary>
     public static class GrpcMESSCDFactory
     {
         public static async Task<IMESSCD> CreateSSCDAsync(GrpcClientOptions options)
         {
+#if NET6_0_OR_GREATER
             var connectionhandler = new GrpcProxyConnectionHandler<IMESSCD>(options);
+#else
+            var connectionhandler = new NativeGrpcProxyConnectionHandler<IMESSCD>(options);
+#endif
 
             if (options.RetryPolicyOptions != null)
             {

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcPosFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcPosFactory.cs
@@ -5,16 +5,17 @@ using System.Threading.Tasks;
 namespace fiskaltrust.Middleware.Interface.Client.Grpc
 {
     /// <summary>
-    /// Create grpc POS Client.
+    /// A factory to create a gRPC-based IPOS client instance for communicating with a Queue package.
     /// </summary>
-    /// <param name="options"></param>
-    /// <returns>proxy</returns>
     public static class GrpcPosFactory
     {
         public static async Task<IPOS> CreatePosAsync(GrpcClientOptions options)
         {
+#if NET6_0_OR_GREATER
             var connectionhandler = new GrpcProxyConnectionHandler<IPOS>(options);
-
+#else
+            var connectionhandler = new NativeGrpcProxyConnectionHandler<IPOS>(options);
+#endif
             if (options.RetryPolicyOptions != null)
             {
                 var retryPolicyHelper = new RetryPolicyHandler<IPOS>(options.RetryPolicyOptions, connectionhandler);

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/NativeGrpcProxyConnectionHandler.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/NativeGrpcProxyConnectionHandler.cs
@@ -1,32 +1,30 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if !NET6_0_OR_GREATER
 
 using fiskaltrust.Middleware.Interface.Client.Common.RetryLogic;
+using Grpc.Core;
 using ProtoBuf.Grpc.Client;
 using System.Threading.Tasks;
-using Grpc.Net.Client;
 
 namespace fiskaltrust.Middleware.Interface.Client.Grpc
 {
-    internal class GrpcProxyConnectionHandler<T> : IProxyConnectionHandler<T> where T : class
+    internal class NativeGrpcProxyConnectionHandler<T> : IProxyConnectionHandler<T> where T : class
     {
         private T _proxy;
-        private GrpcChannel _channel;
+        private Channel _channel;
         private readonly GrpcClientOptions _options;
 
-        public GrpcProxyConnectionHandler(GrpcClientOptions options)
+        public NativeGrpcProxyConnectionHandler(GrpcClientOptions options)
         {
             _options = options;
         }
 
         public Task ReconnectAsync()
         {
-            if (_proxy != null)
+            if (_proxy != null && _channel.State == ChannelState.Ready)
             {
                 return Task.CompletedTask;
             }
-
-            GrpcClientFactory.AllowUnencryptedHttp2 = _options.AllowUnencryptedHttp2;
-            _channel = GrpcChannel.ForAddress(_options.Url, _options.ChannelOptions);
+            _channel = new Channel(_options.Url.Host, _options.Url.Port, _options.ChannelCredentials, _options.ChannelOptions);
             _proxy = _channel.CreateGrpcService<T>();
 
             return Task.CompletedTask;
@@ -45,14 +43,13 @@ namespace fiskaltrust.Middleware.Interface.Client.Grpc
             {
                 // We can ignore the case when shutdown failed
             }
-            GrpcClientFactory.AllowUnencryptedHttp2 = _options.AllowUnencryptedHttp2;
-            _channel = GrpcChannel.ForAddress(_options.Url, _options.ChannelOptions);
+            _channel = new Channel(_options.Url.Host, _options.Url.Port, _options.ChannelCredentials, _options.ChannelOptions);
             _proxy = _channel.CreateGrpcService<T>();
         }
 
         public async Task<T> GetProxyAsync()
         {
-            if (_proxy == null)
+            if (_proxy == null || _channel.State != ChannelState.Ready)
             {
                 await ReconnectAsync();
             }

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/fiskaltrust.Middleware.Interface.Client.Grpc.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/fiskaltrust.Middleware.Interface.Client.Grpc.csproj
@@ -32,7 +32,7 @@
 		</_PackageFiles>
 		<_PackageFiles Include="$(OutputPath)\net6\fiskaltrust.Middleware.Interface.Client.Common.dll">
 			<BuildAction>None</BuildAction>
-			<PackagePath>lib\net6\</PackagePath>
+			<PackagePath>lib\net6.0\</PackagePath>
 		</_PackageFiles>
 	</ItemGroup>
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/fiskaltrust.Middleware.Interface.Client.Grpc.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/fiskaltrust.Middleware.Interface.Client.Grpc.csproj
@@ -1,44 +1,53 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net461;netstandard2.0;net6</TargetFrameworks>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="fiskaltrust.interface" Version="1.3.40" />
-    <PackageReference Include="Grpc.Core" Version="2.28.1" />
-    <PackageReference Include="protobuf-net.Grpc.Native" Version="1.0.37" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net6' ">
+		<PackageReference Include="fiskaltrust.interface" Version="1.3.40" />
+		<PackageReference Include="Grpc.Core" Version="2.28.1" />
+		<PackageReference Include="protobuf-net.Grpc.Native" Version="1.0.37" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\fiskaltrust.Middleware.Interface.Client.Common\fiskaltrust.Middleware.Interface.Client.Common.csproj">
-      <PrivateAssets>all</PrivateAssets>
-    </ProjectReference>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <_PackageFiles Include="$(OutputPath)\net461\fiskaltrust.Middleware.Interface.Client.Common.dll">
-      <BuildAction>None</BuildAction>
-      <PackagePath>lib\net461\</PackagePath>
-    </_PackageFiles>
-    <_PackageFiles Include="$(OutputPath)\netstandard2.0\fiskaltrust.Middleware.Interface.Client.Common.dll">
-      <BuildAction>None</BuildAction>
-      <PackagePath>lib\netstandard2.0\</PackagePath>
-    </_PackageFiles>
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6' ">
+		<PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
+		<PackageReference Include="protobuf-net.Grpc" Version="1.0.179" />
+	</ItemGroup>
 
-  <PropertyGroup>
-    <PackageId>fiskaltrust.Middleware.Interface.Client.Grpc</PackageId>
-    <Authors>fiskaltrust</Authors>
-    <Company>fiskaltrust</Company>
-    <PackageLicenseUrl>https://github.com/fiskaltrust/middleware-interface-dotnet/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/fiskaltrust/middleware-interface-dotnet</PackageProjectUrl>
-    <PackageIconUrl>https://portal.fiskaltrust.at/Content/favicons/favicon-64x64.png</PackageIconUrl>
-    <Description>An optional helper implementation to simplify the usage of the fiskaltrust Middleware interface via gRPC.</Description>
-    <Copyright>Copyright 2020</Copyright>
-    <PackageTags>fiskaltrust interface</PackageTags>
-    <AssemblyCompany>fiskaltrust</AssemblyCompany>
-    <AssemblyProduct>fiskaltrust.Middleware.Interface.Grpc</AssemblyProduct>
-  </PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\fiskaltrust.Middleware.Interface.Client.Common\fiskaltrust.Middleware.Interface.Client.Common.csproj">
+			<PrivateAssets>all</PrivateAssets>
+		</ProjectReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<_PackageFiles Include="$(OutputPath)\net461\fiskaltrust.Middleware.Interface.Client.Common.dll">
+			<BuildAction>None</BuildAction>
+			<PackagePath>lib\net461\</PackagePath>
+		</_PackageFiles>
+		<_PackageFiles Include="$(OutputPath)\netstandard2.0\fiskaltrust.Middleware.Interface.Client.Common.dll">
+			<BuildAction>None</BuildAction>
+			<PackagePath>lib\netstandard2.0\</PackagePath>
+		</_PackageFiles>
+		<_PackageFiles Include="$(OutputPath)\net6\fiskaltrust.Middleware.Interface.Client.Common.dll">
+			<BuildAction>None</BuildAction>
+			<PackagePath>lib\net6\</PackagePath>
+		</_PackageFiles>
+	</ItemGroup>
+
+	<PropertyGroup>
+		<PackageId>fiskaltrust.Middleware.Interface.Client.Grpc</PackageId>
+		<Authors>fiskaltrust</Authors>
+		<Company>fiskaltrust</Company>
+		<PackageLicenseUrl>https://github.com/fiskaltrust/middleware-interface-dotnet/LICENSE</PackageLicenseUrl>
+		<PackageProjectUrl>https://github.com/fiskaltrust/middleware-interface-dotnet</PackageProjectUrl>
+		<PackageIconUrl>https://portal.fiskaltrust.at/Content/favicons/favicon-64x64.png</PackageIconUrl>
+		<Description>An optional helper implementation to simplify the usage of the fiskaltrust Middleware interface via gRPC.</Description>
+		<Copyright>Copyright 2020</Copyright>
+		<PackageTags>fiskaltrust interface</PackageTags>
+		<AssemblyCompany>fiskaltrust</AssemblyCompany>
+		<AssemblyProduct>fiskaltrust.Middleware.Interface.Grpc</AssemblyProduct>
+	</PropertyGroup>
 
 </Project>

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/version.json
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.40",
+  "version": "1.3.42",
   "releaseBranches": [
     "^refs/heads/master$",
     "^refs/tags/client/grpc/v\\d+(?:\\.\\d+)*(?:-.*)?$"

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net6</TargetFrameworks>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
@@ -27,7 +27,7 @@
     </_PackageFiles>
 	  <_PackageFiles Include="$(OutputPath)\net6\fiskaltrust.Middleware.Interface.Client.Common.dll">
 		  <BuildAction>None</BuildAction>
-		  <PackagePath>lib\net6\</PackagePath>
+		  <PackagePath>lib\net6.0\</PackagePath>
 	  </_PackageFiles>
   </ItemGroup>
   

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
@@ -25,6 +25,10 @@
       <BuildAction>None</BuildAction>
       <PackagePath>lib\netstandard2.0\</PackagePath>
     </_PackageFiles>
+	  <_PackageFiles Include="$(OutputPath)\net6\fiskaltrust.Middleware.Interface.Client.Common.dll">
+		  <BuildAction>None</BuildAction>
+		  <PackagePath>lib\net6\</PackagePath>
+	  </_PackageFiles>
   </ItemGroup>
   
   <PropertyGroup>

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/version.json
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.40",
+  "version": "1.3.42",
   "releaseBranches": [
     "^refs/heads/master$",
     "^refs/tags/client/http/v\\d+(?:\\.\\d+)*(?:-.*)?$"

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/SoapProxyConnectionHandler.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/SoapProxyConnectionHandler.cs
@@ -79,8 +79,13 @@ namespace fiskaltrust.Middleware.Interface.Client.Soap
             {
                 "http" => new BasicHttpBinding(BasicHttpSecurityMode.None) { MaxReceivedMessageSize = _options.MaxReceivedMessageSize, SendTimeout = sendTimeout, ReceiveTimeout = _options.ReceiveTimeout },
                 "https" => new BasicHttpBinding(BasicHttpSecurityMode.Transport) { MaxReceivedMessageSize = _options.MaxReceivedMessageSize, SendTimeout = sendTimeout, ReceiveTimeout = _options.ReceiveTimeout },
-                "net.pipe" => new NetNamedPipeBinding(NetNamedPipeSecurityMode.None) { MaxReceivedMessageSize = _options.MaxReceivedMessageSize, SendTimeout = sendTimeout, ReceiveTimeout = _options.ReceiveTimeout },
                 "net.tcp" => new NetTcpBinding(SecurityMode.None) { MaxReceivedMessageSize = _options.MaxReceivedMessageSize, SendTimeout = sendTimeout, ReceiveTimeout = _options.ReceiveTimeout },
+
+#if NET6_0_OR_GREATER
+                "net.pipe" => throw new NotImplementedException("Named pipes are not supported anymore by .NET6+. Please either use an HTTP or NetTcp binding, or migrate to a more modern protocol like gRPC."),
+#else
+                "net.pipe" => new NetNamedPipeBinding(NetNamedPipeSecurityMode.None) { MaxReceivedMessageSize = _options.MaxReceivedMessageSize, SendTimeout = sendTimeout, ReceiveTimeout = _options.ReceiveTimeout },
+#endif
                 _ => throw new ArgumentException($"The url {_options.Url} is not supported.", nameof(_options.Url))
             };
         }

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461;net6</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
@@ -9,6 +9,12 @@
 	  <PackageReference Include="fiskaltrust.interface" Version="1.3.40" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6' ">
+    <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
+  </ItemGroup>
+	
   <ItemGroup>
     <ProjectReference Include="..\fiskaltrust.Middleware.Interface.Client.Common\fiskaltrust.Middleware.Interface.Client.Common.csproj">
       <PrivateAssets>all</PrivateAssets>
@@ -36,7 +42,7 @@
     <AssemblyProduct>fiskaltrust.Middleware.Interface.Soap</AssemblyProduct>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net6' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ServiceModel" />

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
@@ -28,7 +28,7 @@
 		</_PackageFiles>
 		<_PackageFiles Include="$(OutputPath)\net6\fiskaltrust.Middleware.Interface.Client.Common.dll">
 			<BuildAction>None</BuildAction>
-			<PackagePath>lib\net6\</PackagePath>
+			<PackagePath>lib\net6.0\</PackagePath>
 		</_PackageFiles>
 	</ItemGroup>
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
@@ -21,14 +21,18 @@
     </ProjectReference>
   </ItemGroup>
   
-  <ItemGroup>
-    <_PackageFiles Include="$(OutputPath)\fiskaltrust.Middleware.Interface.Client.Common.dll">
-      <BuildAction>None</BuildAction>
-      <PackagePath>lib\net461\</PackagePath>
-    </_PackageFiles>
-  </ItemGroup>
+	<ItemGroup>
+		<_PackageFiles Include="$(OutputPath)\net461\fiskaltrust.Middleware.Interface.Client.Common.dll">
+			<BuildAction>None</BuildAction>
+			<PackagePath>lib\net461\</PackagePath>
+		</_PackageFiles>
+		<_PackageFiles Include="$(OutputPath)\net6\fiskaltrust.Middleware.Interface.Client.Common.dll">
+			<BuildAction>None</BuildAction>
+			<PackagePath>lib\net6\</PackagePath>
+		</_PackageFiles>
+	</ItemGroup>
 
-  <PropertyGroup>
+	<PropertyGroup>
     <PackageId>fiskaltrust.Middleware.Interface.Client.Soap</PackageId>
     <Authors>fiskaltrust</Authors>
     <Company>fiskaltrust</Company>

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/version.json
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.40",
+  "version": "1.3.42",
   "releaseBranches": [
     "^refs/heads/master$",
     "^refs/tags/client/soap/v\\d+(?:\\.\\d+)*(?:-.*)?$"


### PR DESCRIPTION
This PR adds support for .NET 6 in our Middleware clients, including SOAP via WCF and the native .NET implementation of gRPC.