### PR TITLE
Added parameter to disable SSL validation

### DIFF
--- a/src/fiskaltrust.Middleware.Interface.Client.Http/DESSCD/HttpDESSCD.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/DESSCD/HttpDESSCD.cs
@@ -12,7 +12,7 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
     {
         private readonly HttpClient _httpClient;
 
-        public HttpDESSCD(ClientOptions options)
+        public HttpDESSCD(HttpDESSCDClientOptions options)
         {
             _httpClient = GetClient(options);
         }
@@ -90,10 +90,24 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
             return JsonConvert.DeserializeObject<T>(result);
         }
 
-        private HttpClient GetClient(ClientOptions options)
+        private HttpClient GetClient(HttpDESSCDClientOptions options)
         {
             var url = options.Url.ToString().EndsWith("/") ? options.Url : new Uri($"{options.Url}/");
-            return new HttpClient { BaseAddress = url };
+
+            if (options.DisableSslValidation.HasValue && options.DisableSslValidation.Value)
+            {
+                var handler = new HttpClientHandler
+                {
+                    ClientCertificateOptions = ClientCertificateOption.Manual,
+                    ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true
+                };
+
+                return new HttpClient(handler) { BaseAddress = url };
+            }
+            else
+            {
+                return new HttpClient { BaseAddress = url };
+            }
         }
     }
 }

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/DESSCD/HttpDESSCDClientOptions.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/DESSCD/HttpDESSCDClientOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace fiskaltrust.Middleware.Interface.Client.Http
+{
+    /// <summary>
+    /// Used to pass client options to the underlying HTTP client
+    /// </summary>
+    public class HttpDESSCDClientOptions : ClientOptions
+    {
+        public bool? DisableSslValidation { get; set; }
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/DESSCD/HttpDESSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/DESSCD/HttpDESSCDFactory.cs
@@ -9,7 +9,7 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
     /// </summary>
     public static class HttpDESSCDFactory
     {
-        public static async Task<IDESSCD> CreateSSCDAsync(ClientOptions options)
+        public static async Task<IDESSCD> CreateSSCDAsync(HttpDESSCDClientOptions options)
         {
             var connectionhandler = new HttpProxyConnectionHandler<IDESSCD>(new HttpDESSCD(options));
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/ITSSCD/HttpITSSCD.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/ITSSCD/HttpITSSCD.cs
@@ -12,7 +12,7 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
     {
         private readonly HttpClient _httpClient;
 
-        public HttpITSSCD(ClientOptions options)
+        public HttpITSSCD(HttpITSSCDClientOptions options)
         {
             _httpClient = GetClient(options);
         }
@@ -54,10 +54,23 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
             return JsonConvert.DeserializeObject<T>(result);
         }
 
-        private HttpClient GetClient(ClientOptions options)
+        private HttpClient GetClient(HttpITSSCDClientOptions options)
         {
             var url = options.Url.ToString().EndsWith("/") ? options.Url : new Uri($"{options.Url}/");
-            return new HttpClient { BaseAddress = url };
+            if (options.DisableSslValidation.HasValue && options.DisableSslValidation.Value)
+            {
+                var handler = new HttpClientHandler
+                {
+                    ClientCertificateOptions = ClientCertificateOption.Manual,
+                    ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true
+                };
+
+                return new HttpClient(handler) { BaseAddress = url };
+            }
+            else
+            {
+                return new HttpClient { BaseAddress = url };
+            }
         }
     }
 }

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/ITSSCD/HttpITSSCDClientOptions.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/ITSSCD/HttpITSSCDClientOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace fiskaltrust.Middleware.Interface.Client.Http
+{
+    /// <summary>
+    /// Used to pass client options to the underlying HTTP client
+    /// </summary>
+    public class HttpITSSCDClientOptions : ClientOptions
+    {
+        public bool? DisableSslValidation { get; set; }
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/ITSSCD/HttpITSSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/ITSSCD/HttpITSSCDFactory.cs
@@ -9,7 +9,7 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
     /// </summary>
     public static class HttpITSSCDFactory
     {
-        public static async Task<IITSSCD> CreateSSCDAsync(ClientOptions options)
+        public static async Task<IITSSCD> CreateSSCDAsync(HttpITSSCDClientOptions options)
         {
             var connectionhandler = new HttpProxyConnectionHandler<IITSSCD>(new HttpITSSCD(options));
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/MESSCD/HttpMESSCDClientOptions.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/MESSCD/HttpMESSCDClientOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace fiskaltrust.Middleware.Interface.Client.Http
+{
+    /// <summary>
+    /// Used to pass client options to the underlying HTTP client
+    /// </summary>
+    public class HttpMESSCDClientOptions : ClientOptions
+    {
+        public bool? DisableSslValidation { get; set; }
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/MESSCD/HttpMESSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/MESSCD/HttpMESSCDFactory.cs
@@ -9,7 +9,7 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
     /// </summary>
     public static class HttpMESSCDFactory
     {
-        public static async Task<IMESSCD> CreateSSCDAsync(ClientOptions options)
+        public static async Task<IMESSCD> CreateSSCDAsync(HttpMESSCDClientOptions options)
         {
             var connectionhandler = new HttpProxyConnectionHandler<IMESSCD>(new HttpMESSCD(options));
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/POS/HttpPosClientOptions.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/POS/HttpPosClientOptions.cs
@@ -3,7 +3,7 @@
 namespace fiskaltrust.Middleware.Interface.Client.Http
 {
     /// <summary>
-    /// Set Client Options Communication type,Url, CashboxId and AccessToken.
+    /// Used to pass client options to the underlying HTTP client
     /// </summary>
     public class HttpPosClientOptions : ClientOptions
     {

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/POS/HttpPosClientOptions.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/POS/HttpPosClientOptions.cs
@@ -11,6 +11,7 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
         public bool UseUnversionedLegacyUrls { get; set; } = false;
         public Guid? CashboxId { get; set; }
         public string AccessToken { get; set; }
+        public bool? DisableSslValidation { get; set; }
     }
 
     public enum HttpCommunicationType

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/version.json
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.42",
+  "version": "1.3.43",
   "releaseBranches": [
     "^refs/heads/master$",
     "^refs/tags/client/http/v\\d+(?:\\.\\d+)*(?:-.*)?$"

--- a/test/fiskaltrust.Middleware.Interface.Client.Tests/IDESSCD/Wcf/HttpIDESSCDTests.cs
+++ b/test/fiskaltrust.Middleware.Interface.Client.Tests/IDESSCD/Wcf/HttpIDESSCDTests.cs
@@ -27,7 +27,7 @@ namespace fiskaltrust.Middleware.Interface.Client.Tests.IDESSCD.Wcf
                 StopHost();
         }
 
-        protected override ifPOS.v1.de.IDESSCD CreateClient() => HttpDESSCDFactory.CreateSSCDAsync(new HttpPosClientOptions { Url = new Uri(_url), RetryPolicyOptions = _retryPolicyOptions }).Result;
+        protected override ifPOS.v1.de.IDESSCD CreateClient() => HttpDESSCDFactory.CreateSSCDAsync(new HttpDESSCDClientOptions { Url = new Uri(_url), RetryPolicyOptions = _retryPolicyOptions }).Result;
 
         protected override void StartHost()
         {


### PR DESCRIPTION
This PR adds the possibility to bypass the validation of SSL certificates when using the clients via an optional parameter. The default behavior is not affected by this (as the default value of the parameter is `false`).