### PR TITLE
Added IATSSCD v1

### DIFF
--- a/src/fiskaltrust.ifPOS/fiskaltrust.interface.csproj
+++ b/src/fiskaltrust.ifPOS/fiskaltrust.interface.csproj
@@ -8,17 +8,7 @@
     <PackageProjectUrl>https://github.com/fiskaltrust/middleware-interface-dotnet</PackageProjectUrl>
     <PackageIconUrl>https://portal.fiskaltrust.at/Content/favicons/favicon-64x64.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Description>fiskaltrust.interface describes the interface that is used to communicate with the fiskaltrust.Middleware</Description>
-    <PackageReleaseNotes>
-      20161024: Added async-interface definition.
-      20160528: Extended interface definition for journal.
-      20160525: Splitted Utilities into seperated package.
-      20160514: Added support for .net35 and pcl, documentation update.
-      20160512: ReceiptRequest und ReceiptResponse erweitert, Dokumentation aktualisiert.
-      20160418: Zusätzlicher Schnittstellendefinition mit der die verwendeten Signaturerstellungseinheiten veröffentlicht werden.
-      20160214: Zusätzliches Feld cbPreviousReceiptID im ReceiptRequest um auf einen relevanten Vorbeleg verweisen zu können.
-      20151030: Definitin der Schnittstelle
-    </PackageReleaseNotes>
+    <Description>fiskaltrust.interface describes the interface that is used to communicate with the fiskaltrust.Middleware</Description>   
     <Copyright>Copyright 2016</Copyright>
     <PackageTags>fiskaltrust interface</PackageTags>
     <TargetFrameworks>net40;net461;netstandard2.0;netstandard2.1</TargetFrameworks>

--- a/src/fiskaltrust.ifPOS/v0/at/IATSSCD.cs
+++ b/src/fiskaltrust.ifPOS/v0/at/IATSSCD.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.ServiceModel;
+#if WCF
+using System.ServiceModel.Web;
+#endif
 
 namespace fiskaltrust.ifPOS.v0
 {
@@ -14,6 +17,10 @@ namespace fiskaltrust.ifPOS.v0
         /// </summary>
         /// <returns>certificate byte data</returns>
         [OperationContract]
+#if WCF
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v0/certificate", Method = "GET")]
+#endif
+        [Obsolete("This method is obsolete, use CertificateAsync instead.")]
         byte[] Certificate();
 
         /// <summary>
@@ -23,6 +30,7 @@ namespace fiskaltrust.ifPOS.v0
         /// <param name="state"></param>
         /// <returns></returns>
         [OperationContract(AsyncPattern = true)]
+        [Obsolete("This method is obsolete, use CertificateAsync instead.")]
         IAsyncResult BeginCertificate(AsyncCallback callback, object state);
 
         /// <summary>
@@ -30,6 +38,7 @@ namespace fiskaltrust.ifPOS.v0
         /// </summary>
         /// <param name="result"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete, use CertificateAsync instead.")]
         byte[] EndCertificate(IAsyncResult result);
 
         /// <summary>
@@ -37,6 +46,10 @@ namespace fiskaltrust.ifPOS.v0
         /// </summary>
         /// <returns>operator sign</returns>
         [OperationContract]
+#if WCF
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v0/zda", Method = "GET")]
+#endif
+        [Obsolete("This method is obsolete, use ZdaAsync instead.")]
         string ZDA();
 
         /// <summary>
@@ -46,6 +59,7 @@ namespace fiskaltrust.ifPOS.v0
         /// <param name="state"></param>
         /// <returns></returns>
         [OperationContract(AsyncPattern = true)]
+        [Obsolete("This method is obsolete, use ZdaAsync instead.")]
         IAsyncResult BeginZDA(AsyncCallback callback, object state);
 
         /// <summary>
@@ -53,6 +67,7 @@ namespace fiskaltrust.ifPOS.v0
         /// </summary>
         /// <param name="result"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete, use ZdaAsync instead.")]
         string EndZDA(IAsyncResult result);
 
         /// <summary>
@@ -61,6 +76,10 @@ namespace fiskaltrust.ifPOS.v0
         /// <param name="data">payload data</param>
         /// <returns>signature data</returns>
         [OperationContract]
+#if WCF
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v0/sign", Method = "POST")]
+#endif
+        [Obsolete("This method is obsolete, use SignAsync instead.")]
         byte[] Sign(byte[] data);
 
         /// <summary>
@@ -71,6 +90,7 @@ namespace fiskaltrust.ifPOS.v0
         /// <param name="state"></param>
         /// <returns></returns>
         [OperationContract(AsyncPattern = true)]
+        [Obsolete("This method is obsolete, use SignAsync instead.")]
         IAsyncResult BeginSign(byte[] data, AsyncCallback callback, object state);
 
         /// <summary>
@@ -78,6 +98,7 @@ namespace fiskaltrust.ifPOS.v0
         /// </summary>
         /// <param name="result"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete, use SignAsync instead.")]
         byte[] EndSign(IAsyncResult result);
 
         /// <summary>
@@ -86,6 +107,10 @@ namespace fiskaltrust.ifPOS.v0
         /// <param name="message">The test message</param>
         /// <returns>The test message</returns>
         [OperationContract]
+#if WCF
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v0/echo", Method = "POST")]
+#endif
+        [Obsolete("This method is obsolete, use EchoAsync instead.")]
         string Echo(string message);
 
         /// <summary> 
@@ -96,6 +121,7 @@ namespace fiskaltrust.ifPOS.v0
         /// <param name="state"></param>
         /// <returns></returns>
         [OperationContract(AsyncPattern = true)]
+        [Obsolete("This method is obsolete, use EchoAsync instead.")]
         IAsyncResult BeginEcho(string message, AsyncCallback callback, object state);
 
         /// <summary>
@@ -103,6 +129,7 @@ namespace fiskaltrust.ifPOS.v0
         /// </summary>
         /// <param name="result"></param>
         /// <returns></returns>
+        [Obsolete("This method is obsolete, use EchoAsync instead.")]
         string EndEcho(IAsyncResult result);
     }
 }

--- a/src/fiskaltrust.ifPOS/v1/at/IATSSCD.cs
+++ b/src/fiskaltrust.ifPOS/v1/at/IATSSCD.cs
@@ -1,0 +1,51 @@
+﻿using System.ServiceModel;
+using System.Threading.Tasks;
+#if WCF
+using System.ServiceModel.Web;
+#endif
+
+namespace fiskaltrust.ifPOS.v1.at
+{
+    /// <summary>
+    /// This interface is applicable only for the Austrian market and enables direct communication with the signature creation device for own purposes: it can be used for testing if the service is running (“Echo” call), for getting the certificate (“Certificate” call), or signing autono-mously (“Sign” call).
+    /// </summary>
+    [ServiceContract]
+    public interface IATSSCD : v0.IATSSCD
+    {
+        /// <summary>
+        /// Get the certificate of the signature creation device
+        /// </summary>
+        [OperationContract(Name = "v1/Certificate")]
+#if WCF
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v2/certificate", Method = "GET")]
+#endif
+        Task<CertificateResponse> CertificateAsync();
+
+        /// <summary>
+        /// Get the short name of the certificate service provider for RKSV
+        /// </summary>
+        [OperationContract(Name = "v1/ZDA")]
+#if WCF
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v2/zda", Method = "GET")]
+#endif
+        Task<ZdaResponse> ZdaAsync();
+
+        /// <summary>
+        /// Sign data with the signature creation device
+        /// </summary>
+        [OperationContract(Name = "v1/Sign")]
+#if WCF
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v2/sign", Method = "POST")]
+#endif
+        Task<SignResponse> SignAsync(SignRequest signRequest);
+
+        /// <summary>
+        /// Function to test communication
+        /// </summary>
+        [OperationContract(Name = "v1/Echo")]
+#if WCF
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v2/echo", Method = "POST")]
+#endif
+        Task<EchoResponse> EchoAsync(EchoRequest echoRequest);
+    }
+}

--- a/src/fiskaltrust.ifPOS/v1/at/Models/CertificateResponse.cs
+++ b/src/fiskaltrust.ifPOS/v1/at/Models/CertificateResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.Serialization;
+
+namespace fiskaltrust.ifPOS.v1.at
+{
+    [DataContract]
+    public class CertificateResponse
+    {
+        [DataMember(Order = 10)]
+        public byte[] Certificate { get; set; }
+    }
+}

--- a/src/fiskaltrust.ifPOS/v1/at/Models/EchoRequest.cs
+++ b/src/fiskaltrust.ifPOS/v1/at/Models/EchoRequest.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.Serialization;
+
+namespace fiskaltrust.ifPOS.v1.at
+{
+    [DataContract]
+    public class EchoRequest
+    {
+        [DataMember(Order = 10)]
+        public string Message { get; set; }
+    }
+}

--- a/src/fiskaltrust.ifPOS/v1/at/Models/EchoResponse.cs
+++ b/src/fiskaltrust.ifPOS/v1/at/Models/EchoResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.Serialization;
+
+namespace fiskaltrust.ifPOS.v1.at
+{
+    [DataContract]
+    public class EchoResponse
+    {
+        [DataMember(Order = 10)]
+        public string Message { get; set; }
+    }
+}

--- a/src/fiskaltrust.ifPOS/v1/at/Models/SignRequest.cs
+++ b/src/fiskaltrust.ifPOS/v1/at/Models/SignRequest.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.Serialization;
+
+namespace fiskaltrust.ifPOS.v1.at
+{
+    [DataContract]
+    public class SignRequest
+    {
+        [DataMember(Order = 10)]
+        public byte[] Data { get; set; }
+    }
+}

--- a/src/fiskaltrust.ifPOS/v1/at/Models/SignResponse.cs
+++ b/src/fiskaltrust.ifPOS/v1/at/Models/SignResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.Serialization;
+
+namespace fiskaltrust.ifPOS.v1.at
+{
+    [DataContract]
+    public class SignResponse
+    {
+        [DataMember(Order = 10)]
+        public byte[] SignedData { get; set; }
+    }
+}

--- a/src/fiskaltrust.ifPOS/v1/at/Models/ZdaResponse.cs
+++ b/src/fiskaltrust.ifPOS/v1/at/Models/ZdaResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.Serialization;
+
+namespace fiskaltrust.ifPOS.v1.at
+{
+    [DataContract]
+    public class ZdaResponse
+    {
+        [DataMember(Order = 10)]
+        public string ZDA { get; set; }
+    }
+}

--- a/src/fiskaltrust.ifPOS/version.json
+++ b/src/fiskaltrust.ifPOS/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.50-rc1",
+  "version": "1.3.55-rc1",
   "releaseBranches": [
     "^refs/heads/master$",
     "^refs/tags/v\\d+(?:\\.\\d+)*(?:-.*)?$"


### PR DESCRIPTION
This PR adds a new version of the IATSSCD interface that is compatible with gRPC. This requires us to introduce asynchronous methods that don't return value-types, but model classes.

- [x] IATSSCD in fiskaltrust.IPOS
- [ ] gRPC client
- [ ] REST client
- [ ] SOAP client