### PR TITLE
Added Austrian IATSSCD clients

### DIFF
--- a/src/fiskaltrust.Middleware.Interface.Client.Common.StrongName/fiskaltrust.Middleware.Interface.Client.Common.StrongName.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Common.StrongName/fiskaltrust.Middleware.Interface.Client.Common.StrongName.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="fiskaltrust.interface.StrongName" Version="1.3.50-rc1" />
+		<PackageReference Include="fiskaltrust.interface.StrongName" Version="1.3.55-rc1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/fiskaltrust.Middleware.Interface.Client.Common/RetryLogic/ATSSCDRetryProxyClient.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Common/RetryLogic/ATSSCDRetryProxyClient.cs
@@ -1,0 +1,57 @@
+﻿using fiskaltrust.ifPOS.v1.at;
+using System;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Common.RetryLogic
+{
+    public class ATSSCDRetryProxyClient : IATSSCD
+    {
+        private readonly IRetryPolicyHandler<IATSSCD> _retryPolicyHelper;
+
+        public ATSSCDRetryProxyClient(IRetryPolicyHandler<IATSSCD> retryPolicyHelper) => _retryPolicyHelper = retryPolicyHelper;
+
+        [Obsolete]
+        public byte[] Certificate() => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.Certificate())).Result;
+
+        public async Task<CertificateResponse> CertificateAsync() => await _retryPolicyHelper.RetryFuncAsync(async (proxy) => await proxy.CertificateAsync());
+
+        [Obsolete]
+        public IAsyncResult BeginCertificate(AsyncCallback callback, object state) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.BeginCertificate(callback, state))).Result;
+
+        [Obsolete]
+        public byte[] EndCertificate(IAsyncResult result) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.EndCertificate(result))).Result;
+
+        [Obsolete]
+        public string Echo(string message) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.Echo(message))).Result;
+
+        public async Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => await _retryPolicyHelper.RetryFuncAsync(async (proxy) => await proxy.EchoAsync(echoRequest));
+
+        [Obsolete]
+        public IAsyncResult BeginEcho(string message, AsyncCallback callback, object state) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.BeginEcho(message, callback, state))).Result;
+
+        [Obsolete]
+        public string EndEcho(IAsyncResult result) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.EndEcho(result))).Result;
+
+        [Obsolete]
+        public byte[] Sign(byte[] data) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.Sign(data))).Result;
+
+        public async Task<SignResponse> SignAsync(SignRequest signRequest) => await _retryPolicyHelper.RetryFuncAsync(async (proxy) => await proxy.SignAsync(signRequest));
+
+        [Obsolete]
+        public IAsyncResult BeginSign(byte[] data, AsyncCallback callback, object state) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.BeginSign(data, callback, state))).Result;
+
+        [Obsolete]
+        public byte[] EndSign(IAsyncResult result) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.EndSign(result))).Result;
+
+        [Obsolete]
+        public string ZDA() => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.ZDA())).Result;
+
+        public async Task<ZdaResponse> ZdaAsync() => await _retryPolicyHelper.RetryFuncAsync(async (proxy) => await proxy.ZdaAsync());
+
+        [Obsolete]
+        public IAsyncResult BeginZDA(AsyncCallback callback, object state) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.BeginZDA(callback, state))).Result;
+
+        [Obsolete]
+        public string EndZDA(IAsyncResult result) => _retryPolicyHelper.RetryFuncAsync(async (proxy) => await Task.FromResult(proxy.EndZDA(result))).Result;
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Common/fiskaltrust.Middleware.Interface.Client.Common.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Common/fiskaltrust.Middleware.Interface.Client.Common.csproj
@@ -7,6 +7,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="fiskaltrust.interface" Version="1.3.50-rc1" />
+		<PackageReference Include="fiskaltrust.interface" Version="1.3.55-rc1" />
 	</ItemGroup>
 </Project>

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcATSSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcATSSCDFactory.cs
@@ -1,0 +1,28 @@
+﻿using fiskaltrust.ifPOS.v1.at;
+using fiskaltrust.Middleware.Interface.Client.Common.RetryLogic;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Grpc
+{
+    public static class GrpcATSSCDFactory
+    {
+        public static async Task<IATSSCD> CreateSSCDAsync(GrpcClientOptions options)
+        {
+#if NET6_0_OR_GREATER
+            var connectionhandler = new GrpcProxyConnectionHandler<IATSSCD>(options);
+#else
+            var connectionhandler = new NativeGrpcProxyConnectionHandler<IATSSCD>(options);
+#endif
+
+            if (options.RetryPolicyOptions != null)
+            {
+                var retryPolicyHelper = new RetryPolicyHandler<IATSSCD>(options.RetryPolicyOptions, connectionhandler);
+                return new ATSSCDRetryProxyClient(retryPolicyHelper);
+            }
+            else
+            {
+                return await connectionhandler.GetProxyAsync();
+            }
+        }
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/fiskaltrust.Middleware.Interface.Client.Grpc.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/fiskaltrust.Middleware.Interface.Client.Grpc.csproj
@@ -4,8 +4,11 @@
 		<TargetFrameworks>net461;netstandard2.0;net6</TargetFrameworks>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<PackageReference Include="fiskaltrust.interface" Version="1.3.55-rc1" />		
+	</ItemGroup>
+	
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net6' ">
-		<PackageReference Include="fiskaltrust.interface" Version="1.3.50-rc1" />
 		<PackageReference Include="Grpc.Core" Version="2.28.1" />
 		<PackageReference Include="protobuf-net.Grpc.Native" Version="1.0.37" />
 	</ItemGroup>

--- a/src/fiskaltrust.Middleware.Interface.Client.Http.StrongName/fiskaltrust.Middleware.Interface.Client.Http.StrongName.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http.StrongName/fiskaltrust.Middleware.Interface.Client.Http.StrongName.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="fiskaltrust.interface.StrongName" Version="1.3.50-rc1" />
+	<PackageReference Include="fiskaltrust.interface.StrongName" Version="1.3.55-rc1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/ATSSCD/HttpATSSCD.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/ATSSCD/HttpATSSCD.cs
@@ -1,0 +1,135 @@
+﻿using fiskaltrust.ifPOS.v1.at;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Http
+{
+    internal class HttpATSSCD : IATSSCD
+    {
+        private readonly HttpClient _httpClient;
+
+        private delegate string AsyncEchoCaller(string message);
+        private delegate byte[] AsyncCertificateCaller();
+        private delegate string AsyncZdaCaller();
+        private delegate byte[] AsyncSignCaller(byte[] data);
+
+        public HttpATSSCD(HttpATSSCDClientOptions options)
+        {
+            _httpClient = GetClient(options);
+        }
+
+        public async Task<CertificateResponse> CertificateAsync() => await ExecuteHttpGetAsync<CertificateResponse>("v2", "Certificate").ConfigureAwait(false);
+
+        public async Task<ZdaResponse> ZdaAsync() => await ExecuteHttpGetAsync<ZdaResponse>("v2", "Zda").ConfigureAwait(false);
+
+        public async Task<SignResponse> SignAsync(SignRequest signRequest) => await ExecuteHttpPostAsync<SignResponse>("v2", "Sign", signRequest).ConfigureAwait(false);
+
+        public async Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => await ExecuteHttpPostAsync<EchoResponse>("v2", "Echo", echoRequest).ConfigureAwait(false);
+
+        public byte[] Certificate() => Task.Run(async () => await ExecuteHttpGetAsync<byte[]>("v0", "Certificate").ConfigureAwait(false)).Result;
+
+        public IAsyncResult BeginCertificate(AsyncCallback callback, object state)
+        {
+            var d = new AsyncCertificateCaller((this as ifPOS.v0.IATSSCD).Certificate);
+            return d.BeginInvoke(callback, d);
+        }
+
+        public byte[] EndCertificate(IAsyncResult result)
+        {
+            var d = (AsyncCertificateCaller)result.AsyncState;
+            return d.EndInvoke(result);
+        }
+
+        public string ZDA() => Task.Run(async () => await ExecuteHttpGetAsync<string>("v0", "ZDA").ConfigureAwait(false)).Result;
+
+        public IAsyncResult BeginZDA(AsyncCallback callback, object state)
+        {
+            var d = new AsyncZdaCaller((this as ifPOS.v0.IATSSCD).ZDA);
+            return d.BeginInvoke(callback, d);
+        }
+
+        public string EndZDA(IAsyncResult result)
+        {
+            var d = (AsyncZdaCaller)result.AsyncState;
+            return d.EndInvoke(result);
+        }
+
+        public byte[] Sign(byte[] data) => Task.Run(async () => await ExecuteHttpPostAsync<byte[]>("v0", "Sign", data).ConfigureAwait(false)).Result;
+
+        public IAsyncResult BeginSign(byte[] data, AsyncCallback callback, object state)
+        {
+            var d = new AsyncSignCaller((this as ifPOS.v0.IATSSCD).Sign);
+            return d.BeginInvoke(data, callback, d);
+        }
+
+        public byte[] EndSign(IAsyncResult result)
+        {
+            var d = (AsyncSignCaller)result.AsyncState;
+            return d.EndInvoke(result);
+        }
+
+        public string Echo(string message) => Task.Run(async () => await ExecuteHttpPostAsync<string>("v0", "Echo", message).ConfigureAwait(false)).Result;
+
+        public IAsyncResult BeginEcho(string message, AsyncCallback callback, object state)
+        {
+            var d = new AsyncEchoCaller((this as ifPOS.v0.IATSSCD).Echo);
+            return d.BeginInvoke(message, callback, d);
+        }
+
+        public string EndEcho(IAsyncResult result)
+        {
+            var d = (AsyncEchoCaller)result.AsyncState;
+            return d.EndInvoke(result);
+        }
+
+        private async Task<T> ExecuteHttpPostAsync<T>(string urlVersion, string urlMethod, object parameter = null)
+        {
+            var url = Path.Combine(urlVersion, urlMethod);
+            StringContent stringContent = null;
+
+            if (parameter != null)
+            {
+                var json = JsonConvert.SerializeObject(parameter);
+                stringContent = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+            var response = await _httpClient.PostAsync(url, stringContent).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<T>(result);
+        }
+
+        private async Task<T> ExecuteHttpGetAsync<T>(string urlVersion, string urlMethod)
+        {
+            var url = Path.Combine(urlVersion, urlMethod);
+            var response = await _httpClient.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<T>(result);
+        }
+
+        private HttpClient GetClient(HttpATSSCDClientOptions options)
+        {
+            var url = options.Url.ToString().EndsWith("/") ? options.Url : new Uri($"{options.Url}/");
+            if (options.DisableSslValidation.HasValue && options.DisableSslValidation.Value)
+            {
+                var handler = new HttpClientHandler
+                {
+                    ClientCertificateOptions = ClientCertificateOption.Manual,
+                    ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true
+                };
+
+                return new HttpClient(handler) { BaseAddress = url };
+            }
+            else
+            {
+                return new HttpClient { BaseAddress = url };
+            }
+        }
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/ATSSCD/HttpATSSCD.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/ATSSCD/HttpATSSCD.cs
@@ -22,13 +22,13 @@ namespace fiskaltrust.Middleware.Interface.Client.Http
             _httpClient = GetClient(options);
         }
 
-        public async Task<CertificateResponse> CertificateAsync() => await ExecuteHttpGetAsync<CertificateResponse>("v2", "Certificate").ConfigureAwait(false);
+        public async Task<CertificateResponse> CertificateAsync() => await ExecuteHttpGetAsync<CertificateResponse>("v1", "Certificate").ConfigureAwait(false);
 
-        public async Task<ZdaResponse> ZdaAsync() => await ExecuteHttpGetAsync<ZdaResponse>("v2", "Zda").ConfigureAwait(false);
+        public async Task<ZdaResponse> ZdaAsync() => await ExecuteHttpGetAsync<ZdaResponse>("v1", "Zda").ConfigureAwait(false);
 
-        public async Task<SignResponse> SignAsync(SignRequest signRequest) => await ExecuteHttpPostAsync<SignResponse>("v2", "Sign", signRequest).ConfigureAwait(false);
+        public async Task<SignResponse> SignAsync(SignRequest signRequest) => await ExecuteHttpPostAsync<SignResponse>("v1", "Sign", signRequest).ConfigureAwait(false);
 
-        public async Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => await ExecuteHttpPostAsync<EchoResponse>("v2", "Echo", echoRequest).ConfigureAwait(false);
+        public async Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => await ExecuteHttpPostAsync<EchoResponse>("v1", "Echo", echoRequest).ConfigureAwait(false);
 
         public byte[] Certificate() => Task.Run(async () => await ExecuteHttpGetAsync<byte[]>("v0", "Certificate").ConfigureAwait(false)).Result;
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/ATSSCD/HttpATSSCDClientOptions.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/ATSSCD/HttpATSSCDClientOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace fiskaltrust.Middleware.Interface.Client.Http
+{
+    /// <summary>
+    /// Used to pass client options to the underlying HTTP client
+    /// </summary>
+    public class HttpATSSCDClientOptions : ClientOptions
+    {
+        public bool? DisableSslValidation { get; set; }
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/ATSSCD/HttpATSSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/ATSSCD/HttpATSSCDFactory.cs
@@ -1,0 +1,27 @@
+﻿using fiskaltrust.ifPOS.v1.at;
+using fiskaltrust.Middleware.Interface.Client.Common.RetryLogic;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Http.ATSSCD
+{
+    /// <summary>
+    /// A factory to create a HTTP-based IATSSCD client instance for communicating with an Austrian SCU package.
+    /// </summary>
+    public static class HttpATSSCDFactory
+    {
+        public static async Task<IATSSCD> CreateSSCDAsync(HttpATSSCDClientOptions options)
+        {
+            var connectionhandler = new HttpProxyConnectionHandler<IATSSCD>(new HttpATSSCD(options));
+
+            if (options.RetryPolicyOptions != null)
+            {
+                var retryPolicyHelper = new RetryPolicyHandler<IATSSCD>(options.RetryPolicyOptions, connectionhandler);
+                return new ATSSCDRetryProxyClient(retryPolicyHelper);
+            }
+            else
+            {
+                return await connectionhandler.GetProxyAsync();
+            }
+        }
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="fiskaltrust.interface" Version="1.3.50-rc1" />
+    <PackageReference Include="fiskaltrust.interface" Version="1.3.55-rc1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/SoapATSSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/SoapATSSCDFactory.cs
@@ -1,0 +1,37 @@
+﻿using fiskaltrust.ifPOS.v1.at;
+using fiskaltrust.Middleware.Interface.Client.Common.RetryLogic;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Soap
+{
+    /// <summary>
+    /// A factory to create a SOAP-based IATSSCD client instance for communicating with an Austrian SCU package.
+    /// </summary>
+    public static class SoapATSSCDFactory
+    {
+        public static async Task<IATSSCD> CreateSSCDAsync(ClientOptions options)
+        {
+            var soapClientOptions = new SoapClientOptions
+            {
+                RetryPolicyOptions = options.RetryPolicyOptions,
+                Url = options.Url
+            };
+            return await CreateSSCDAsync(soapClientOptions);
+        }
+
+        public static async Task<IATSSCD> CreateSSCDAsync(SoapClientOptions options)
+        {
+            var connectionhandler = new SoapProxyConnectionHandler<IATSSCD>(options);
+
+            if (options.RetryPolicyOptions != null)
+            {
+                var retryPolicyHelper = new RetryPolicyHandler<IATSSCD>(options.RetryPolicyOptions, connectionhandler);
+                return new ATSSCDRetryProxyClient(retryPolicyHelper);
+            }
+            else
+            {
+                return await connectionhandler.GetProxyAsync();
+            }
+        }
+    }
+}

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="fiskaltrust.interface" Version="1.3.50-rc1" />
+		<PackageReference Include="fiskaltrust.interface" Version="1.3.55-rc1" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6' ">

--- a/src/fiskaltrust.ifPOS/v1/at/IATSSCD.cs
+++ b/src/fiskaltrust.ifPOS/v1/at/IATSSCD.cs
@@ -17,7 +17,7 @@ namespace fiskaltrust.ifPOS.v1.at
         /// </summary>
         [OperationContract(Name = "v1/Certificate")]
 #if WCF
-        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v2/certificate", Method = "GET")]
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v1/certificate", Method = "GET")]
 #endif
         Task<CertificateResponse> CertificateAsync();
 
@@ -26,7 +26,7 @@ namespace fiskaltrust.ifPOS.v1.at
         /// </summary>
         [OperationContract(Name = "v1/ZDA")]
 #if WCF
-        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v2/zda", Method = "GET")]
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v1/zda", Method = "GET")]
 #endif
         Task<ZdaResponse> ZdaAsync();
 
@@ -35,7 +35,7 @@ namespace fiskaltrust.ifPOS.v1.at
         /// </summary>
         [OperationContract(Name = "v1/Sign")]
 #if WCF
-        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v2/sign", Method = "POST")]
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v1/sign", Method = "POST")]
 #endif
         Task<SignResponse> SignAsync(SignRequest signRequest);
 
@@ -44,7 +44,7 @@ namespace fiskaltrust.ifPOS.v1.at
         /// </summary>
         [OperationContract(Name = "v1/Echo")]
 #if WCF
-        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v2/echo", Method = "POST")]
+        [WebInvoke(BodyStyle = WebMessageBodyStyle.Bare, UriTemplate = "v1/echo", Method = "POST")]
 #endif
         Task<EchoResponse> EchoAsync(EchoRequest echoRequest);
     }


### PR DESCRIPTION
This PR adds the HTTP, SOAP and gRPC clients for the newly added v1.IATSSCD interface. These clients are required to use the upcoming 1.3+ packages with the new Launchers (1.3, 2.0+).