### PR TITLE
add missing chargeitemflags to ifPos/v2

### DIFF
--- a/src/fiskaltrust.ifPOS/v2/Cases/ChargeItemCaseFlags.cs
+++ b/src/fiskaltrust.ifPOS/v2/Cases/ChargeItemCaseFlags.cs
@@ -8,6 +8,12 @@ public enum ChargeItemCaseFlags : ulong
     Refund = 0x0000_0000_0002_0000,
     /// <value><c>0x0000_0000_0004_0000</c></value>
     ExtraOrDiscount = 0x0000_0000_0004_0000,
+    /// <value><c>0x0000_0000_0008_0000</c></value>
+    Downpayment = 0x0000_0000_0008_0000,
+    /// <value><c>0x0000_0000_0010_0000</c></value>
+    ReturnableDeposit = 0x0000_0000_0010_0000,
+    /// <value><c>0x0000_0000_0020_0000</c></value>
+    TakeAway = 0x0000_0000_0020_0000,
 }
 
 public static class ChargeItemCaseFlagsExt


### PR DESCRIPTION
## Pull request overview

This PR updates the `fiskaltrust.ifPOS` v2 case-flag surface area by adding missing `ChargeItemCaseFlags` entries so integrators can represent Downpayment, ReturnableDeposit, and TakeAway scenarios on `ChargeItemCase` values.

**Changes:**
- Added `Downpayment` flag to `ChargeItemCaseFlags` (`0x0000_0000_0008_0000`).
- Added `ReturnableDeposit` flag to `ChargeItemCaseFlags` (`0x0000_0000_0010_0000`).
- Added `TakeAway` flag to `ChargeItemCaseFlags` (`0x0000_0000_0020_0000`).


Fixes [#{issue 167}](https://github.com/fiskaltrust/market-at/issues/167)
