### PR TITLE
Re-add IPLSSCD client factories with interface pin 1.3.79-rc1

### DIFF
--- a/src/fiskaltrust.Middleware.Interface.Client.Common/RetryLogic/PLSSCDRetryProxyClient.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Common/RetryLogic/PLSSCDRetryProxyClient.cs
@@ -1,0 +1,19 @@
+#if SYSTEM_TEXT_JSON
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.pl;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Common.RetryLogic
+{
+    public class PLSSCDRetryProxyClient : IPLSSCD
+    {
+        private readonly IRetryPolicyHandler<IPLSSCD> _retryPolicyHelper;
+        public PLSSCDRetryProxyClient(IRetryPolicyHandler<IPLSSCD> retryPolicyHelper) => _retryPolicyHelper = retryPolicyHelper;
+
+        public async Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => await _retryPolicyHelper.RetryFuncAsync(async (proxy) => await proxy.EchoAsync(echoRequest));
+        public async Task<PLSSCDInfo> GetInfoAsync() => await _retryPolicyHelper.RetryFuncAsync(async (proxy) => await proxy.GetInfoAsync());
+
+        public async Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request) => await _retryPolicyHelper.RetryFuncAsync(async (proxy) => await proxy.ProcessReceiptAsync(request));
+    }
+}
+#endif

--- a/src/fiskaltrust.Middleware.Interface.Client.Common/fiskaltrust.Middleware.Interface.Client.Common.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Common/fiskaltrust.Middleware.Interface.Client.Common.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="fiskaltrust.interface" Version="1.3.76-rc1" />
+	  <PackageReference Include="fiskaltrust.interface" Version="1.3.79-rc1" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)' != 'net40' AND '$(TargetFramework)' != 'net461'">

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcPLSSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/GrpcPLSSCDFactory.cs
@@ -1,0 +1,33 @@
+#if SYSTEM_TEXT_JSON
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Interface.Client.Common.RetryLogic;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Grpc
+{
+    /// <summary>
+    /// A factory to create a gRPC-based IPLSSCD client instance for communicating with a Polish SCU package.
+    /// </summary>
+    public static class GrpcPLSSCDFactory
+    {
+        public static async Task<IPLSSCD> CreateSSCDAsync(GrpcClientOptions options)
+        {
+#if NET6_0_OR_GREATER
+            var connectionhandler = new GrpcProxyConnectionHandler<IPLSSCD>(options);
+#else
+            var connectionhandler = new NativeGrpcProxyConnectionHandler<IPLSSCD>(options);
+#endif
+
+            if (options.RetryPolicyOptions != null)
+            {
+                var retryPolicyHelper = new RetryPolicyHandler<IPLSSCD>(options.RetryPolicyOptions, connectionhandler);
+                return new PLSSCDRetryProxyClient(retryPolicyHelper);
+            }
+            else
+            {
+                return await connectionhandler.GetProxyAsync();
+            }
+        }
+    }
+}
+#endif

--- a/src/fiskaltrust.Middleware.Interface.Client.Grpc/fiskaltrust.Middleware.Interface.Client.Grpc.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Grpc/fiskaltrust.Middleware.Interface.Client.Grpc.csproj
@@ -19,7 +19,7 @@
  	</ItemGroup>
 
  	<ItemGroup>
- 	  <PackageReference Include="fiskaltrust.interface" Version="1.3.76-rc1" />
+ 	  <PackageReference Include="fiskaltrust.interface" Version="1.3.79-rc1" />
  	</ItemGroup>
 
 	<ItemGroup>

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/PLSSCD/HttpPLSSCD.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/PLSSCD/HttpPLSSCD.cs
@@ -1,0 +1,95 @@
+#if SYSTEM_TEXT_JSON
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.pl;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Http
+{
+    public class HttpPLSSCD : IPLSSCD
+    {
+        private readonly HttpClient _httpClient;
+
+        public HttpPLSSCD(HttpPLSSCDClientOptions options)
+        {
+            _httpClient = GetClient(options);
+        }
+        public async Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => await ExecuteHttpPostAsync<EchoResponse>("Echo", echoRequest).ConfigureAwait(false);
+        public async Task<PLSSCDInfo> GetInfoAsync() => await ExecuteHttpGetAsync<PLSSCDInfo>("GetInfo").ConfigureAwait(false);
+
+        public async Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request) => await ExecuteHttpPostAsync<ProcessResponse>("ProcessReceipt", request).ConfigureAwait(false);
+
+
+        private async Task<T> ExecuteHttpPostAsync<T>(string urlPath, object parameter = null)
+        {
+            var url = ConstructPath(urlPath);
+            StringContent stringContent = null;
+
+            if (parameter != null)
+            {
+                var json = JsonSerializer.Serialize(parameter);
+                stringContent = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+            var response = await _httpClient.PostAsync(url, stringContent).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                throw new Exception($"Request failed with status {response.StatusCode}: {errorContent}", new HttpRequestException(errorContent));
+            }
+
+            var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonSerializer.Deserialize<T>(result);
+        }
+
+        private async Task<T> ExecuteHttpGetAsync<T>(string urlPath)
+        {
+            var url = ConstructPath(urlPath);
+            var response = await _httpClient.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                throw new Exception($"Request failed with status {response.StatusCode}: {errorContent}", new HttpRequestException(errorContent));
+            }
+
+            var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonSerializer.Deserialize<T>(result);
+        }
+
+        private string ConstructPath(string urlPath) => Path.Combine("v2", urlPath);
+
+        private HttpClient GetClient(HttpPLSSCDClientOptions options)
+        {
+            HttpClient httpClient;
+            var url = options.Url.ToString().EndsWith("/") ? options.Url : new Uri($"{options.Url}/");
+            if (options.DisableSslValidation.HasValue && options.DisableSslValidation.Value)
+            {
+                var handler = new HttpClientHandler
+                {
+                    ClientCertificateOptions = ClientCertificateOption.Manual,
+                    ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true
+                };
+
+                httpClient = new HttpClient(handler) { BaseAddress = url };
+            }
+            else
+            {
+                httpClient = new HttpClient { BaseAddress = url };
+            }
+            if (options.CashboxId.HasValue)
+            {
+                httpClient.DefaultRequestHeaders.Add("x-cashbox-id", options.CashboxId.ToString());
+            }
+            if (!string.IsNullOrEmpty(options.AccessToken))
+            {
+                httpClient.DefaultRequestHeaders.Add("x-cashbox-accesstoken", options.AccessToken);
+            }
+
+            return httpClient;
+        }
+    }
+}
+#endif

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/PLSSCD/HttpPLSSCDClientOptions.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/PLSSCD/HttpPLSSCDClientOptions.cs
@@ -1,0 +1,16 @@
+#if SYSTEM_TEXT_JSON
+using System;
+
+namespace fiskaltrust.Middleware.Interface.Client.Http
+{
+    /// <summary>
+    /// Used to pass client options to the underlying HTTP client
+    /// </summary>
+    public class HttpPLSSCDClientOptions : ClientOptions
+    {
+        public bool? DisableSslValidation { get; set; }
+        public Guid? CashboxId { get; set; }
+        public string AccessToken { get; set; }
+    }
+}
+#endif

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/PLSSCD/HttpPLSSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/PLSSCD/HttpPLSSCDFactory.cs
@@ -1,0 +1,29 @@
+#if SYSTEM_TEXT_JSON
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Interface.Client.Common.RetryLogic;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Http
+{
+    /// <summary>
+    /// Create Http SSCD.
+    /// </summary>
+    public static class HttpPLSSCDFactory
+    {
+        public static async Task<IPLSSCD> CreateSSCDAsync(HttpPLSSCDClientOptions options)
+        {
+            var connectionhandler = new HttpProxyConnectionHandler<IPLSSCD>(new HttpPLSSCD(options));
+
+            if (options.RetryPolicyOptions != null)
+            {
+                var retryPolicyHelper = new RetryPolicyHandler<IPLSSCD>(options.RetryPolicyOptions, connectionhandler);
+                return new PLSSCDRetryProxyClient(retryPolicyHelper);
+            }
+            else
+            {
+                return await connectionhandler.GetProxyAsync();
+            }
+        }
+    }
+}
+#endif

--- a/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Http/fiskaltrust.Middleware.Interface.Client.Http.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="fiskaltrust.interface" Version="1.3.76-rc1" />
+    <PackageReference Include="fiskaltrust.interface" Version="1.3.79-rc1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/SoapPLSSCDFactory.cs
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/SoapPLSSCDFactory.cs
@@ -1,0 +1,39 @@
+#if SYSTEM_TEXT_JSON
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Interface.Client.Common.RetryLogic;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Soap
+{
+    /// <summary>
+    /// Create SOAP SSCD.
+    /// </summary>
+    public static class SoapPLSSCDFactory
+    {
+        public static async Task<IPLSSCD> CreateSSCDAsync(ClientOptions options)
+        {
+            var soapClientOptions = new SoapClientOptions
+            {
+                RetryPolicyOptions = options.RetryPolicyOptions,
+                Url = options.Url
+            };
+            return await CreateSSCDAsync(soapClientOptions);
+        }
+
+        public static async Task<IPLSSCD> CreateSSCDAsync(SoapClientOptions options)
+        {
+            var connectionhandler = new SoapProxyConnectionHandler<IPLSSCD>(options);
+
+            if (options.RetryPolicyOptions != null)
+            {
+                var retryPolicyHelper = new RetryPolicyHandler<IPLSSCD>(options.RetryPolicyOptions, connectionhandler);
+                return new PLSSCDRetryProxyClient(retryPolicyHelper);
+            }
+            else
+            {
+                return await connectionhandler.GetProxyAsync();
+            }
+        }
+    }
+}
+#endif

--- a/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
+++ b/src/fiskaltrust.Middleware.Interface.Client.Soap/fiskaltrust.Middleware.Interface.Client.Soap.csproj
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="fiskaltrust.interface" Version="1.3.76-rc1" />
+	  <PackageReference Include="fiskaltrust.interface" Version="1.3.79-rc1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/fiskaltrust.Middleware.Interface.Client.Tests/Helpers/DummyPLSSCD.cs
+++ b/test/fiskaltrust.Middleware.Interface.Client.Tests/Helpers/DummyPLSSCD.cs
@@ -1,0 +1,33 @@
+#if SYSTEM_TEXT_JSON
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.pl;
+using System;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.Interface.Client.Tests.Helpers
+{
+    public class DummyPLSSCD : ifPOS.v2.pl.IPLSSCD
+    {
+        public Task<EchoResponse> EchoAsync(EchoRequest echoRequest)
+            => Task.FromResult(new EchoResponse
+            {
+                Message = echoRequest.Message
+            });
+
+        public Task<PLSSCDInfo> GetInfoAsync()
+            => Task.FromResult(new PLSSCDInfo
+            {
+                InfoData = "{\"serialNumber\":\"ABC1234567\",\"uniqueDeviceNumber\":\"ZAS1234567890\",\"crkReachable\":true}"
+            });
+
+        public Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request)
+            => Task.FromResult(new ProcessResponse
+            {
+                ReceiptResponse = new ReceiptResponse
+                {
+                    ftCashBoxID = Guid.NewGuid()
+                }
+            });
+    }
+}
+#endif

--- a/test/fiskaltrust.Middleware.Interface.Client.Tests/IPLSSCD/Http/HttpIPLSSCDTests.cs
+++ b/test/fiskaltrust.Middleware.Interface.Client.Tests/IPLSSCD/Http/HttpIPLSSCDTests.cs
@@ -1,0 +1,142 @@
+#if !WCF && SYSTEM_TEXT_JSON
+using fiskaltrust.Middleware.Interface.Client.Tests.Helpers;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using fiskaltrust.ifPOS.v2.pl;
+using System.Text;
+using fiskaltrust.ifPOS.v2;
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
+using System.IO;
+using fiskaltrust.Middleware.Interface.Client.Http;
+using FluentAssertions;
+
+namespace fiskaltrust.Middleware.Interface.Client.Tests.IPLSSCD
+{
+    public class HttpIPLSSCDTests : IPLSSCDTests
+    {
+        private string _url;
+        private IWebHost _webHost;
+
+        public HttpIPLSSCDTests()
+        {
+            _url = $"http://localhost:8081/scu/{Guid.NewGuid()}";
+        }
+
+        ~HttpIPLSSCDTests()
+        {
+            _webHost?.Dispose();
+        }
+
+        protected override ifPOS.v2.pl.IPLSSCD CreateClient() => HttpPLSSCDFactory.CreateSSCDAsync(new HttpPLSSCDClientOptions
+        {
+            Url = new Uri(_url)
+        }).Result;
+
+
+        protected override void StartHost()
+        {
+            var uri = new Uri(_url);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            var pathBase = uri.AbsolutePath.TrimEnd('/');
+
+            _webHost = new WebHostBuilder()
+                .UseKestrel()
+                .UseUrls(baseUrl)
+                .ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddSingleton<ifPOS.v2.pl.IPLSSCD, DummyPLSSCD>();
+                })
+                .Configure(app =>
+                {
+                    app.UsePathBase(pathBase);
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapPost("/v2/processreceipt", async context =>
+                        {
+                            var scd = context.RequestServices.GetService<ifPOS.v2.pl.IPLSSCD>();
+                            var requestBody = await new StreamReader(context.Request.Body).ReadToEndAsync();
+                            var request = JsonSerializer.Deserialize<ProcessRequest>(requestBody);
+                            var response = await scd.ProcessReceiptAsync(request);
+                            context.Response.ContentType = "application/json";
+                            await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+                        });
+
+                        endpoints.MapPost("/v2/echo", async context =>
+                        {
+                            var scd = context.RequestServices.GetService<ifPOS.v2.pl.IPLSSCD>();
+                            var requestBody = await new StreamReader(context.Request.Body).ReadToEndAsync();
+                            var request = JsonSerializer.Deserialize<EchoRequest>(requestBody);
+                            var response = await scd.EchoAsync(request);
+                            context.Response.ContentType = "application/json";
+                            await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+                        });
+
+                        endpoints.MapGet("/v2/getinfo", async context =>
+                        {
+                            var scd = context.RequestServices.GetService<ifPOS.v2.pl.IPLSSCD>();
+                            var response = await scd.GetInfoAsync();
+                            context.Response.ContentType = "application/json";
+                            await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+                        });
+                    });
+                })
+                .Build();
+
+            _webHost.Start();
+        }
+
+        protected override void StopHost()
+        {
+            _webHost?.Dispose();
+            _webHost = null;
+        }
+
+        [Test]
+        public async Task ProcessReceipt_ShouldReturn()
+        {
+            using (var httpClient = new HttpClient())
+            {
+                var requestData = new ProcessRequest();
+                var content = new StringContent(JsonSerializer.Serialize(requestData), Encoding.UTF8, "application/json");
+                var result = await httpClient.PostAsync(new Uri(_url + "/v2/processreceipt"), content);
+                result.EnsureSuccessStatusCode();
+                var response = JsonSerializer.Deserialize<ProcessResponse>(await result.Content.ReadAsStringAsync());
+                response.ReceiptResponse.Should().NotBeNull();
+                response.ReceiptResponse.ftCashBoxID.ToString().Should().NotBeNullOrEmpty();
+            }
+        }
+
+        [Test]
+        public async Task Echo_ShouldReturn()
+        {
+            using (var httpClient = new HttpClient())
+            {
+                var requestData = new EchoRequest();
+                var content = new StringContent(JsonSerializer.Serialize(requestData), Encoding.UTF8, "application/json");
+                var result = await httpClient.PostAsync(new Uri(_url + "/v2/echo"), content);
+                result.EnsureSuccessStatusCode();
+            }
+        }
+
+        [Test]
+        public async Task GetInfo_ShouldReturn()
+        {
+            using (var httpClient = new HttpClient())
+            {
+                var result = await httpClient.GetAsync(new Uri(_url + "/v2/getinfo"));
+                result.EnsureSuccessStatusCode();
+                var response = JsonSerializer.Deserialize<PLSSCDInfo>(await result.Content.ReadAsStringAsync());
+                response.InfoData.Should().NotBeNullOrEmpty();
+            }
+        }
+    }
+}
+#endif

--- a/test/fiskaltrust.Middleware.Interface.Client.Tests/IPLSSCD/IPLSSCDTests.cs
+++ b/test/fiskaltrust.Middleware.Interface.Client.Tests/IPLSSCD/IPLSSCDTests.cs
@@ -1,0 +1,52 @@
+#if SYSTEM_TEXT_JSON
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.pl;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace fiskaltrust.Middleware.Interface.Client.Tests.IPLSSCD
+{
+    public abstract class IPLSSCDTests
+    {
+        protected abstract void StartHost();
+        protected abstract void StopHost();
+        protected abstract ifPOS.v2.pl.IPLSSCD CreateClient();
+
+        [OneTimeSetUp]
+        public void BaseSetUp() => StartHost();
+
+        [OneTimeTearDown]
+        public void BaseTearDown() => StopHost();
+
+        [Test]
+        public void EchoAsync_ShouldReturn()
+        {
+            var client = CreateClient();
+            var result = client.EchoAsync(new EchoRequest
+            {
+                Message = "test"
+            }).Result;
+            result.Should().NotBeNull();
+        }
+
+        [Test]
+        public void GetInfoAsync_ShouldReturn()
+        {
+            var client = CreateClient();
+            var result = client.GetInfoAsync().Result;
+            result.Should().NotBeNull();
+            result.InfoData.Should().NotBeNullOrEmpty();
+        }
+
+        [Test]
+        public void ProcessReceiptAsync_ShouldReturn()
+        {
+            var client = CreateClient();
+            var result = client.ProcessReceiptAsync(new ProcessRequest { }).Result;
+            result.Should().NotBeNull();
+            result.ReceiptResponse.Should().NotBeNull();
+            result.ReceiptResponse.ftCashBoxID.ToString().Should().NotBeNullOrEmpty();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Stacked on #108. Restores the nine PL client files from #106 **unchanged** and bumps the four client csproj pins `fiskaltrust.interface` 1.3.76-rc1 → **1.3.79-rc1**.

StrongName client projects are untouched: they don't define `SYSTEM_TEXT_JSON`, so the guarded PL sources compile out there (same reason the ES client code never required StrongName pin bumps — `Client.Common.StrongName` still pins 1.3.73-rc5).

## Merge order

1. #108 merges → master builds again → CI publishes `1.3.79-rc1-<build>` to the middleware feed (optionally tag `v1.3.79-rc1` for the exact, code-signed cut)
2. Retarget this PR to `master`, let the pipeline restore the new package → green
3. Merge — PL client factories are back, this time compilable

NuGet's minimum-version resolution makes the pin work either way: it resolves to exact `1.3.79-rc1` once the tag build publishes it, or to the lowest `1.3.79-rc1-<build>` CI package otherwise (same mechanism the middleware repo's `1.3.78-rc1` pin uses today).

**Tracked in** fiskaltrust/market-pl#48 (sub-issue of fiskaltrust/market-pl#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
